### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/robisonpedroso0089-web/grokzomborg-evolved/security/code-scanning/4](https://github.com/robisonpedroso0089-web/grokzomborg-evolved/security/code-scanning/4)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required by this workflow, either at the top (workflow-level, applying to all jobs) or inside the specific job. Since this workflow just checks out code, sets up Python, installs dependencies, lints, and runs tests, it only needs read access to repository contents; the recommended minimal setting is `permissions: contents: read`.

The best way to fix this particular file without changing existing functionality is to add a workflow-level `permissions` block near the top, after the `on:` section and before `jobs:`. This will apply to all jobs (currently just `build`) and clearly document that the `GITHUB_TOKEN` may only read repository contents. No imports, methods, or additional definitions are required: this is purely a YAML configuration change within `.github/workflows/python-package.yml`.

Concretely, in `.github/workflows/python-package.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (ending at line 10) and the `jobs:` key (line 12). No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
