### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/robisonpedroso0089-web/grokzomborg-evolved/security/code-scanning/2](https://github.com/robisonpedroso0089-web/grokzomborg-evolved/security/code-scanning/2)

In general, this should be fixed by explicitly specifying a `permissions` block that limits the default `GITHUB_TOKEN` privileges to the minimum required. For a simple CI workflow that only checks out code and builds it, read-only access to repository contents is typically sufficient.

The best fix here is to add a `permissions` block at the workflow root (applies to all jobs) or inside the `build` job (applies only to that job). Since there is only one job, either is fine; using the root-level `permissions` is clearer and matches the CodeQL suggestion. We will add, near the top of `.github/workflows/jekyll-docker.yml`, just after the `on:` section (or just before `jobs:`), the following:

```yaml
permissions:
  contents: read
```

This ensures the `GITHUB_TOKEN` can only read repository contents and cannot write to the repo, issues, or pull requests. No additional imports or methods are needed; it is purely a YAML configuration change within `.github/workflows/jekyll-docker.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
